### PR TITLE
wifi_ctrl_webconfig: add null check for data

### DIFF
--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -1241,6 +1241,10 @@ int webconfig_vif_neighbors_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_da
 
     wifi_util_dbg_print(WIFI_MGR,"%s %d \n", __func__, __LINE__);
 
+    if (data == NULL) { 
+      return RETURN_ERR;
+    }
+
     mgr_cfg_map = mgr->vif_neighbors_map;
     dec_cfg_map = data->vif_neighbors_map;
 


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @fwph and @eelenberg.

The file source/core/wifi_ctrl_webconfig.c is modified to add a null check for the `data` variable before it is dereferenced. If `data` is null, the function returns immediately with `RETURN_ERR`.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>