### PR TITLE
wifi_ctrl_webconfig: add null check for data

### DIFF
--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -1065,6 +1065,11 @@ int webconfig_steering_clients_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded
 
     wifi_util_dbg_print(WIFI_MGR,"%s %d \n", __func__, __LINE__);
 
+    if (data == NULL) {  
+        wifi_util_dbg_print(WIFI_MGR, "Error: decoded data is NULL\n");
+        return RETURN_ERR;
+    }
+
     mgr_cfg_map = mgr->steering_client_map;
     dec_cfg_map = data->steering_client_map;
 


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @fwph and @eelenberg.

The file source/core/wifi_ctrl_webconfig.c is modified to add a null check for `data` in the `webconfig_steering_clients_apply` function. If `data` is null, the function logs an error and returns immediately with `RETURN_ERR` to prevent null pointer dereferences.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>