### PR TITLE
wifi_ctrl_wifiapi_handlers: add null check for dev_array

### DIFF
--- a/source/core/wifi_ctrl_wifiapi_handlers.c
+++ b/source/core/wifi_ctrl_wifiapi_handlers.c
@@ -611,60 +611,67 @@ static void wifiapi_handle_get_ApAssocDeviceDiagnosticResult(char **args, unsign
         sta_key_t sta_key;
 	sta_key_t mld_sta_key;
 	int vap_index;
-	 vap_index = atoi(args[1]);
-	 wifi_associated_dev3_t *dev_array = NULL;
-	 unsigned int num_devs = 0;
-		if (wifi_getApAssociatedDeviceDiagnosticResult3(vap_index, &dev_array, &num_devs) != RETURN_OK) {
-          snprintf(result_buf, result_buf_size, "Failed to get AP Associated Device Diagnostic Result\n");
-	     if (dev_array != NULL) {
-             free(dev_array);
-             dev_array = NULL;
-         }
-         return;
-      }
-		char* to_sta_key(uint8_t *mac_address, sta_key_t sta_key) {
+	vap_index = atoi(args[1]);
+	wifi_associated_dev3_t *dev_array = NULL;
+	unsigned int num_devs = 0;
+	
+	if (wifi_getApAssociatedDeviceDiagnosticResult3(vap_index, &dev_array, &num_devs) != RETURN_OK) {
+	    snprintf(result_buf, result_buf_size, "Failed to get AP Associated Device Diagnostic Result\n");
+	    if (dev_array != NULL) {
+	        free(dev_array);
+	        dev_array = NULL;
+	    }
+	    return;
+	}
+
+	if (dev_array == NULL) {
+	    snprintf(result_buf, result_buf_size, "Error: dev_array is NULL after device diagnostic result\n");
+	    return;
+	}
+
+	char* to_sta_key(uint8_t *mac_address, sta_key_t sta_key) {
     snprintf(sta_key, STA_KEY_LEN, "%02x:%02x:%02x:%02x:%02x:%02x",
              mac_address[0], mac_address[1], mac_address[2],
              mac_address[3], mac_address[4], mac_address[5]);
     return sta_key;
 }
-      snprintf(result_buf, result_buf_size, "diag result: number of devs: %d\n", num_devs);
-      for (unsigned int i = 0; i < num_devs; i++) {
-              snprintf(result_buf, result_buf_size,
-	          "\ncli_MACAddress: %s cli_MLDAddr: %s cli_MLDEnable: %d cli_AuthenticationState: %d"
-              " cli_LastDataDownlinkRate: %d cli_LastDataUplinkRate: %d cli_SignalStrength: %d"
-              " cli_Retransmissions: %d cli_Active: %d cli_OperatingStandard: %s"
-              " cli_OperatingChannelBandwidth: %s cli_SNR: %d cli_InterferenceSources: %s"
-              " cli_DataFramesSentAck: %lu cli_DataFramesSentNoAck: %lu cli_BytesSent: %lu"
-              " cli_BytesReceived: %lu cli_RSSI: %d cli_MinRSSI: %d cli_MaxRSSI: %d"
-              " cli_Disassociations: %d cli_AuthenticationFailures: %d cli_Associations: %llu"
-              " cli_PacketsSent: %lu cli_PacketsReceived: %lu cli_ErrorsSent: %lu"
-              " cli_RetransCount: %lu cli_FailedRetransCount: %lu cli_RetryCount: %lu"
-              " cli_MultipleRetryCount: %lu cli_MaxDownlinkRate: %d cli_MaxUplinkRate: %d"
-              " cli_activeNumSpatialStreams: %d cli_TxFrames: %llu cli_RxRetries: %llu"
-              " cli_RxErrors: %llu\n",
-              to_sta_key(dev_array[i].cli_MACAddress, sta_key),
-              to_sta_key(dev_array[i].cli_MLDAddr, mld_sta_key), dev_array[i].cli_MLDEnable,
-              dev_array[i].cli_AuthenticationState, dev_array[i].cli_LastDataDownlinkRate,
-              dev_array[i].cli_LastDataUplinkRate, dev_array[i].cli_SignalStrength,
-              dev_array[i].cli_Retransmissions, dev_array[i].cli_Active,
-              dev_array[i].cli_OperatingStandard, dev_array[i].cli_OperatingChannelBandwidth,
-              dev_array[i].cli_SNR, dev_array[i].cli_InterferenceSources,
-              dev_array[i].cli_DataFramesSentAck, dev_array[i].cli_DataFramesSentNoAck,
-              dev_array[i].cli_BytesSent, dev_array[i].cli_BytesReceived, dev_array[i].cli_RSSI,
-              dev_array[i].cli_MinRSSI, dev_array[i].cli_MaxRSSI, dev_array[i].cli_Disassociations,
-              dev_array[i].cli_AuthenticationFailures, dev_array[i].cli_Associations,
-              dev_array[i].cli_PacketsSent, dev_array[i].cli_PacketsReceived,
-              dev_array[i].cli_ErrorsSent, dev_array[i].cli_RetransCount,
-              dev_array[i].cli_FailedRetransCount, dev_array[i].cli_RetryCount,
-              dev_array[i].cli_MultipleRetryCount, dev_array[i].cli_MaxDownlinkRate,
-              dev_array[i].cli_MaxUplinkRate, dev_array[i].cli_activeNumSpatialStreams,
-              dev_array[i].cli_TxFrames, dev_array[i].cli_RxRetries, dev_array[i].cli_RxErrors);
-      if (dev_array != NULL) {
-        free(dev_array);
-        dev_array = NULL;
-    }
-      }
+	snprintf(result_buf, result_buf_size, "diag result: number of devs: %d\n", num_devs);
+	for (unsigned int i = 0; i < num_devs; i++) {
+	    snprintf(result_buf, result_buf_size,
+	        "\ncli_MACAddress: %s cli_MLDAddr: %s cli_MLDEnable: %d cli_AuthenticationState: %d"
+            " cli_LastDataDownlinkRate: %d cli_LastDataUplinkRate: %d cli_SignalStrength: %d"
+            " cli_Retransmissions: %d cli_Active: %d cli_OperatingStandard: %s"
+            " cli_OperatingChannelBandwidth: %s cli_SNR: %d cli_InterferenceSources: %s"
+            " cli_DataFramesSentAck: %lu cli_DataFramesSentNoAck: %lu cli_BytesSent: %lu"
+            " cli_BytesReceived: %lu cli_RSSI: %d cli_MinRSSI: %d cli_MaxRSSI: %d"
+            " cli_Disassociations: %d cli_AuthenticationFailures: %d cli_Associations: %llu"
+            " cli_PacketsSent: %lu cli_PacketsReceived: %lu cli_ErrorsSent: %lu"
+            " cli_RetransCount: %lu cli_FailedRetransCount: %lu cli_RetryCount: %lu"
+            " cli_MultipleRetryCount: %lu cli_MaxDownlinkRate: %d cli_MaxUplinkRate: %d"
+            " cli_activeNumSpatialStreams: %d cli_TxFrames: %llu cli_RxRetries: %llu"
+            " cli_RxErrors: %llu\n",
+	        to_sta_key(dev_array[i].cli_MACAddress, sta_key),
+	        to_sta_key(dev_array[i].cli_MLDAddr, mld_sta_key), dev_array[i].cli_MLDEnable,
+	        dev_array[i].cli_AuthenticationState, dev_array[i].cli_LastDataDownlinkRate,
+	        dev_array[i].cli_LastDataUplinkRate, dev_array[i].cli_SignalStrength,
+	        dev_array[i].cli_Retransmissions, dev_array[i].cli_Active,
+	        dev_array[i].cli_OperatingStandard, dev_array[i].cli_OperatingChannelBandwidth,
+	        dev_array[i].cli_SNR, dev_array[i].cli_InterferenceSources,
+	        dev_array[i].cli_DataFramesSentAck, dev_array[i].cli_DataFramesSentNoAck,
+	        dev_array[i].cli_BytesSent, dev_array[i].cli_BytesReceived, dev_array[i].cli_RSSI,
+	        dev_array[i].cli_MinRSSI, dev_array[i].cli_MaxRSSI, dev_array[i].cli_Disassociations,
+	        dev_array[i].cli_AuthenticationFailures, dev_array[i].cli_Associations,
+	        dev_array[i].cli_PacketsSent, dev_array[i].cli_PacketsReceived,
+	        dev_array[i].cli_ErrorsSent, dev_array[i].cli_RetransCount,
+	        dev_array[i].cli_FailedRetransCount, dev_array[i].cli_RetryCount,
+	        dev_array[i].cli_MultipleRetryCount, dev_array[i].cli_MaxDownlinkRate,
+	        dev_array[i].cli_MaxUplinkRate, dev_array[i].cli_activeNumSpatialStreams,
+	        dev_array[i].cli_TxFrames, dev_array[i].cli_RxRetries, dev_array[i].cli_RxErrors);
+	}
+	if (dev_array != NULL) {
+		free(dev_array);
+		dev_array = NULL;
+	}
 }
 
 void process_wifiapi_command(char *command, unsigned int len)


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @eelenberg and @fwph.

The file source/core/wifi_ctrl_wifiapi_handlers.c is modified to prevent a null pointer dereference in the function
wifiapi_handle_get_ApAssocDeviceDiagnosticResult. The deallocation of dev_array is moved outside of the for loop to prevent a null pointer dereference when num_devs > 1. In addition, if the value of dev_array is null after calling wifi_getApAssociatedDeviceDiagnosticResult3, the function logs an error and returns early.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>