### PR TITLE
wifi_ctrl: add null check for name

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -603,6 +603,11 @@ bool check_for_greylisted_mac_filter(void)
 
 void bus_get_vap_init_parameter(const char *name, unsigned int *ret_val)
 {
+    if (name == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d 'name' is NULL\n", __func__, __LINE__);
+        return;
+    }
+
     int rc = bus_error_success;
     unsigned int total_slept = 0;
     char *pTmp = NULL;


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @fwph and @eelenberg.

The file source/core/wifi_ctrl.c is modified to add a null check for the `name` parameter at the beginning of the `bus_get_vap_init_parameter` function before it is dereferenced. If `name` is null, the function logs an error and returns immediately.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>