### PR TITLE
wifi_ctrl_webconfig: add null check for data 

### DIFF
--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -967,6 +967,11 @@ static bool is_memwraptool_param_changed(wifi_global_config_t *data_config)
 
 int webconfig_stats_config_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_data_t *data)
 {
+    if (data == NULL) {
+        wifi_util_dbg_print(WIFI_CTRL, "%s %d: Error: 'data' is NULL\n", __func__, __LINE__);
+        return RETURN_ERR;
+    }
+
     wifi_mgr_t *mgr = get_wifimgr_obj();
     stats_config_t  *mgr_stats_config, *dec_stats_config, *temp_stats_config;
     hash_map_t *mgr_cfg_map, *dec_cfg_map;


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @eelenberg and @fwph.

The file source/core/wifi_ctrl_webconfig.c is modified to add a null check for the `data` parameter at the beginning of the `webconfig_stats_config_apply` function. If `data` is null, the function logs an error and returns `RETURN_ERR` to prevent null pointer dereferences.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>