### PR TITLE
wifi_db_apis: fixup null pointer dereference

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -2651,15 +2651,18 @@ void wifidb_get_wifi_macfilter_config()
 
         if ((l_rdk_vap_array != NULL) && (l_rdk_vap_array->acl_map != NULL)) {
             tmp_mac = strdup(pcfg->device_mac);
+            if (tmp_mac == NULL) {
+                wifi_util_dbg_print(WIFI_DB,"%s:%d: NULL Pointer \n", __func__, __LINE__);
+                pcfg++;
+                continue;
+            }
             str_tolower(tmp_mac);
             tmp_acl_entry = hash_map_get(l_rdk_vap_array->acl_map, tmp_mac);
             if (tmp_acl_entry == NULL) {
                 tmp_acl_entry = (acl_entry_t *)malloc(sizeof(acl_entry_t));
                 if (tmp_acl_entry == NULL) {
                     wifi_util_dbg_print(WIFI_DB,"%s:%d: NULL Pointer \n", __func__, __LINE__);
-                    if(tmp_mac) {
-                        free(tmp_mac);
-                    }
+                    free(tmp_mac);
                     return;
                 }
                 memset(tmp_acl_entry, 0, sizeof(acl_entry_t));
@@ -2683,9 +2686,7 @@ void wifidb_get_wifi_macfilter_config()
                 tmp_acl_entry->expiry_time = pcfg->expiry_time;
             }
 
-            if(tmp_mac) {
-                free(tmp_mac);
-            }
+            free(tmp_mac);
         }
         pcfg++;
     }


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI
Coder and reviewed by @eelenberg and @fwph.

This adds a null check for `tmp_mac` after the `strdup` call and
prints an error message if it is null. It also simplifies the cleanup of `tmp_mac` by
removing the conditional check before freeing it.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>

